### PR TITLE
Test: add unit tests for RolesGuard and roles decorator

### DIFF
--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -10,7 +10,7 @@ export class RolesGuard implements CanActivate {
     canActivate(context: ExecutionContext): boolean {
         const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [context.getHandler(), context.getClass()]);
 
-        if (!requiredRoles) return true; // If no roles are required, allow access
+        if (!requiredRoles || requiredRoles.length == 0) return true; // If no roles are required, allow access
 
         // Get the user from the request object (JWT)
         const { user } = context.switchToHttp().getRequest();

--- a/test/auth/decorators/roles.decorator.spec.ts
+++ b/test/auth/decorators/roles.decorator.spec.ts
@@ -1,0 +1,16 @@
+import { Reflector } from "@nestjs/core";
+import { ROLES_KEY, Roles } from "../../../src/auth/decorators/roles.decorator";
+import { UserRole } from "../../../src/common/enums/user.enums";
+
+describe("Roles Decorator", () => {
+    it("should define metadata for roles", () => {
+        class TestClass {
+            @Roles(UserRole.ADMIN, UserRole.REGULAR_USER)
+            testMethod() {}
+        }
+
+        const reflector = new Reflector();
+        const roles = reflector.get(ROLES_KEY, TestClass.prototype.testMethod);
+        expect(roles).toEqual(["admin", "regular_user"]);
+    });
+});

--- a/test/auth/guards/roles.guard.spec.ts
+++ b/test/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,55 @@
+import { RolesGuard } from "../../../src/auth/guards/roles.guard";
+import { Reflector } from "@nestjs/core";
+import { ExecutionContext } from "@nestjs/common";
+import { UserRole } from "../../../src/common/enums/user.enums";
+
+describe("RolesGuard", () => {
+    let guard: RolesGuard;
+    let reflector: Reflector;
+
+    beforeEach(() => {
+        reflector = { getAllAndOverride: jest.fn() } as any;
+        guard = new RolesGuard(reflector);
+    });
+
+    const mockExecutionContext = (userRole?: UserRole) => {
+        const req = { user: { role: userRole } };
+        return {
+            switchToHttp: () => ({
+                getRequest: () => req,
+            }),
+            getHandler: jest.fn(),
+            getClass: jest.fn(),
+        } as unknown as ExecutionContext;
+    };
+
+    it("should allow access if no roles are required", () => {
+        jest.spyOn(reflector, "getAllAndOverride").mockReturnValue(undefined);
+        const context = mockExecutionContext(UserRole.ADMIN);
+        expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it("should allow access if user has required role", () => {
+        jest.spyOn(reflector, "getAllAndOverride").mockReturnValue([UserRole.ADMIN]);
+        const context = mockExecutionContext(UserRole.ADMIN);
+        expect(guard.canActivate(context)).toBe(true);
+    });
+
+    it("should deny access if user does not have required role", () => {
+        jest.spyOn(reflector, "getAllAndOverride").mockReturnValue([UserRole.ADMIN]);
+        const context = mockExecutionContext(UserRole.REGULAR_USER);
+        expect(guard.canActivate(context)).toBe(false);
+    });
+
+    it("should deny access if user is missing from request", () => {
+        jest.spyOn(reflector, "getAllAndOverride").mockReturnValue([UserRole.ADMIN]);
+        const context = mockExecutionContext(undefined);
+        expect(guard.canActivate(context)).toBe(false);
+    });
+
+    it("should allow access if requiredRoles is empty array", () => {
+        jest.spyOn(reflector, "getAllAndOverride").mockReturnValue([]);
+        const context = mockExecutionContext(UserRole.REGULAR_USER);
+        expect(guard.canActivate(context)).toBe(true);
+    });
+});


### PR DESCRIPTION
This pull request introduces enhancements to the role-based access control mechanism and adds comprehensive unit tests for the `RolesGuard` and `Roles` decorator. 