### PR TITLE
Feat: add /me endpoint to retrieve current authenticated user

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { JwtModule } from "@nestjs/jwt";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { JwtConfigType } from "src/core/config/types/jwt-config.type";
 import { PassportModule } from "@nestjs/passport";
+import { JwtStrategy } from "./strategies/jwt.strategy";
 
 @Module({
     imports: [
@@ -28,7 +29,8 @@ import { PassportModule } from "@nestjs/passport";
             },
         }),
     ],
-    providers: [AuthService],
+    providers: [AuthService, JwtStrategy],
+    exports: [JwtModule],
     controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard("jwt") {}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -9,13 +9,13 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         super({
             jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
             ignoreExpiration: false,
-            secretOrKey: configService.get("jwt.secret"),
+            secretOrKey: configService.get<string>("jwt.secret"),
         });
     }
 
     async validate(payload: any) {
         return {
-            id: payload.sub,
+            id: payload.id,
             email: payload.email,
             role: payload.role,
         };

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,6 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+
+export const CurrentUser = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+});

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOkResponse, ApiTags, ApiUnauthorizedResponse } from "@nestjs/swagger";
+import { CurrentUser } from "../common/decorators/current-user.decorator";
+import { User } from "./entities/user.entity";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+
+@ApiTags("Users")
+@Controller("users")
+export class UsersController {
+    constructor() {}
+
+    @Get("me")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOkResponse({ description: "Returns current user data." })
+    @ApiUnauthorizedResponse({ description: "Unauthorized" })
+    getProfile(@CurrentUser() user: User): User {
+        return user;
+    }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,10 +2,12 @@ import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { User } from "./entities/user.entity";
 import { UsersService } from "./users.service";
+import { UsersController } from "./users.controller";
 
 @Module({
     imports: [TypeOrmModule.forFeature([User])],
     providers: [UsersService],
+    controllers: [UsersController],
     exports: [UsersService],
 })
 export class UsersModule {}

--- a/test/users/users.controller.spec.ts
+++ b/test/users/users.controller.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { UsersController } from "../../src/users/users.controller";
+import { User } from "../../src/users/entities/user.entity";
+import { JwtAuthGuard } from "../../src/auth/guards/jwt-auth.guard";
+
+describe("UsersController", () => {
+    let controller: UsersController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [UsersController],
+        })
+            .overrideGuard(JwtAuthGuard)
+            .useValue({ canActivate: () => true }) // Mock del guard
+            .compile();
+
+        controller = module.get<UsersController>(UsersController);
+    });
+
+    describe("getProfile", () => {
+        it("should return the current authenticated user", () => {
+            const mockUser = {
+                id: 1,
+                email: "test@example.com",
+                role: "REGULAR_USER",
+            } as User;
+
+            const result = controller.getProfile(mockUser);
+            expect(result).toEqual(mockUser);
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces authentication and authorization enhancements, including the implementation of JWT-based authentication, the addition of a `CurrentUser` decorator, and the creation of a `UsersController` with a protected endpoint to retrieve the current user's profile. It also includes a test suite for the new controller. 