### PR TITLE
Release: Integrate support for `DATABASE_URL` configuration

### DIFF
--- a/src/core/config/config.schema.ts
+++ b/src/core/config/config.schema.ts
@@ -9,6 +9,7 @@ export const configSchema = Joi.object({
     DB_PASSWORD: Joi.string().required(),
     DB_NAME: Joi.string().required(),
     DB_SYNCHRONIZE: Joi.boolean().default(false),
+    DATABASE_URL: Joi.string().uri().optional(),
     JWT_SECRET: Joi.string().required(),
     JWT_EXPIRES_IN: Joi.string().required(),
     SWAPI_URL: Joi.string().uri().required(),

--- a/src/core/config/loaders/config.loader.ts
+++ b/src/core/config/loaders/config.loader.ts
@@ -12,6 +12,7 @@ export const configLoader = (): ConfigLoaderType => ({
         password: process.env.DB_PASSWORD,
         database: process.env.DB_NAME,
         synchronize: process.env.DB_SYNCHRONIZE === "true",
+        url: process.env.DATABASE_URL,
     },
     jwt: {
         secret: process.env.JWT_SECRET,

--- a/src/core/config/types/database-config.type.ts
+++ b/src/core/config/types/database-config.type.ts
@@ -5,4 +5,5 @@ export type DatabaseConfigType = {
     password: string;
     database: string;
     synchronize: boolean;
+    url?: string;
 };

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -12,6 +12,17 @@ import { DatabaseConfigType } from "./config/types/database-config.type";
             imports: [ConfigModule],
             useFactory: (configService: ConfigService) => {
                 const databaseConfig = configService.get<DatabaseConfigType>("database");
+                // This feature is for Railway deployment compatibility.
+                if (databaseConfig.url) {
+                    return {
+                        type: "postgres",
+                        url: databaseConfig.url,
+                        synchronize: false,
+                        autoLoadEntities: true,
+                        migrations: ["dist/migrations/*.js"],
+                        migrationsRun: true,
+                    };
+                }
                 return {
                     type: "postgres",
                     host: databaseConfig.host,


### PR DESCRIPTION
This pull request introduces support for an optional `DATABASE_URL` configuration to enhance compatibility with Railway deployments. It modifies the configuration schema, loader, and database configuration type to accommodate this new environment variable and adjusts the database connection logic accordingly.