### PR TITLE
Fix: remove automatic migration execution on deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,5 @@ COPY --from=builder /app/typeorm.config.ts ./
 
 EXPOSE 8080
 
-CMD ["sh", "-c", "npm run migration:run && node dist/main.js"]
+# CMD ["sh", "-c", "npm run migration:run && node dist/main.js"]
+CMD ["node", "dist/main.js"]


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change updates the `CMD` instruction to remove the execution of database migrations during container startup, simplifying the startup process.