### PR TITLE
Release: Add user roles and enum values to README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,33 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
-## 🔐 Authentication in app
+## 🔐 Authentication and Roles
 
 The project uses JWT-based authentication with role-based access control. Users must log in to receive a token, which must be included in subsequent requests to access protected routes. Guards and custom decorators are used to enforce authentication and role permissions (ADMIN, REGULAR_USER).
+
+### 🛡️ Roles and Permissions
+
+This API uses role-based access control. The available roles are defined as follows:
+
+```code
+export enum UserRole {
+    ADMIN = "admin",
+    REGULAR_USER = "regular_user",
+}
+```
+
+
+- **regular_user**:
+  - Can view movie data.
+  - Cannot create, update, or delete movies.
+  - Cannot trigger synchronization.
+
+- **admin**:
+  - Full access to movie management (create, update, delete).
+  - Can manually trigger synchronization with the Star Wars API.
+  - Can access protected admin routes.
+
+These roles are validated through route guards and custom decorators to ensure secure access.
 
 ## 💾 Production Environment
 

--- a/src/common/dto/create-user.dto.ts
+++ b/src/common/dto/create-user.dto.ts
@@ -23,6 +23,7 @@ export class CreateUserDto {
     @IsNotEmpty()
     @ApiProperty({
         example: UserRole.REGULAR_USER,
+        enum: UserRole,
     })
     role: UserRole;
 }


### PR DESCRIPTION
This pull request enhances the documentation and codebase to incorporate role-based access control (RBAC) and improve clarity on user roles. The changes include updates to the `README.md` file to detail roles and permissions and modifications to the `CreateUserDto` class to specify the available roles using the `UserRole` enum.
